### PR TITLE
Add require statement for the rollup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ yarn add glimmer-redux
 yarn add rollup-plugin-glimmer-redux
 ```
 
-Open the ember-cli-build.js file and add the rollup plugin
+Open the ember-cli-build.js file and import the rollup plugin
+
+```js
+const glimmerRedux = require('rollup-plugin-glimmer-redux');
+```
+
+Then, add the plugin to the list of rollup plugins
 
 ```js
 let app = new GlimmerApp(defaults, {


### PR DESCRIPTION
This is obvious to someone familiar with `ember-cli-build.js` and rollup plugins, but maybe not to new users of Glimmer who come onboard because of this library.